### PR TITLE
Removed extra closing parentheses from sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,5 @@ print bold(red("Bad things happened!"))
 
 # 256 colors are available from tremendous.ext
 from tremendous.ext import darkgreen
-print darkgreen("Crisis averted"))
+print darkgreen("Crisis averted")
 ```


### PR DESCRIPTION
Looks like the crisis wasn't completely averted. :stuck_out_tongue: 

&mdash; @citruspi
